### PR TITLE
Consider numpy views

### DIFF
--- a/src/JupyterPlugin/MVData.cpp
+++ b/src/JupyterPlugin/MVData.cpp
@@ -313,7 +313,7 @@ static std::string add_new_mvdata(const py::array& data, std::string dataSetName
         point_setter = set_points_from_numpy_array<float, double>;
     else
     {
-        qDebug() << "add_mvimage: type not supported (e.g. uint64_t or int64_t)" << QString(guid.c_str());
+        qDebug() << "add_mvimage: type not supported (e.g. uint64_t or int64_t): " << QString(dtype.kind());
         return guid;
     }
 
@@ -388,7 +388,7 @@ static std::string add_mvimage(const py::array& data, std::string dataSetName)
         point_setter = conv_points_from_numpy_array<float, double>;
     else
     {
-        qDebug() << "add_mvimage: type not supported (e.g. uint64_t or int64_t)" << QString(guid.c_str());
+        qDebug() << "add_mvimage: type not supported (e.g. uint64_t or int64_t): " << QString(dtype.kind());
         return guid;
     }
 

--- a/src/JupyterPlugin/MVData.cpp
+++ b/src/JupyterPlugin/MVData.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <numeric>
 #include <string>
 #include <stdexcept>
 #include <type_traits>
@@ -51,14 +52,15 @@ py::array populate_pyarray(
     unsigned int numPoints, 
     unsigned int numDimensions)
 {
+    std::vector<unsigned int> dim_indices(numDimensions);
+    std::iota(dim_indices.begin(), dim_indices.end(), 0);
+
     std::vector<T> data;
-    std::vector<unsigned int> indices;
     auto size = numPoints * numDimensions;
     data.resize(size);
-    for (int i = 0; i < numDimensions; i++) {
-        indices.push_back(i);
-    }
-    inputPoints->populateDataForDimensions<std::vector<T>, std::vector<unsigned int>>(data, indices);
+
+    inputPoints->populateDataForDimensions<std::vector<T>, std::vector<unsigned int>>(data, dim_indices);
+
     auto result = py::array_t<T>({numPoints, numDimensions});
     py::buffer_info result_info = result.request();
     T* output = static_cast<T*>(result_info.ptr);

--- a/src/JupyterPlugin/MVData.cpp
+++ b/src/JupyterPlugin/MVData.cpp
@@ -512,25 +512,22 @@ static std::string add_cluster(const py::tuple& tupleOfClusterLists, std::string
     Dataset<Clusters> clusters = mv::data().createDataset("Cluster", dataSetName.c_str(), parent->getDataset<Points>());
 
     for (size_t i = 0; i < names_list.size(); ++i) {
-        auto indexes = clusters_list[i].cast<py::array>();
-        std::string name = names_list[i].cast<py::str>();
-        auto colorTup = colors_list[i].cast<py::tuple>();
-        std::string id = ids_list[i].cast<py::str>();
+        auto indexes        = clusters_list[i].cast<py::array>();
+        std::string name    = names_list[i].cast<py::str>();
+        auto colorTup       = colors_list[i].cast<py::tuple>();
+        std::string id      = ids_list[i].cast<py::str>();
+
         Cluster cluster;
-        cluster.setName(QString("cluster %1").arg(QString::number(i + 1)));
-        auto clusterIndices = indexes.cast<std::vector<std::uint32_t>>();
-        // cluster indexes
-        cluster.setIndices(clusterIndices);
-        // cluster color
-        auto a = (colorTup.size() == 4) ? colorTup[3].cast<float>() : 1.0;
-        auto clusterColor = QColor::fromRgbF(colorTup[0].cast<float>(), colorTup[1].cast<float>(), colorTup[2].cast<float>(), a);
-        cluster.setColor(clusterColor);
-        // cluster 
         cluster.setName(name.c_str());
-        // Use the auto generated id
+
+        auto clusterIndices = indexes.cast<std::vector<std::uint32_t>>();
+        cluster.setIndices(clusterIndices);
+
+        auto alpha = (colorTup.size() == 4) ? colorTup[3].cast<float>() : 1.0;
+        auto clusterColor = QColor::fromRgbF(colorTup[0].cast<float>(), colorTup[1].cast<float>(), colorTup[2].cast<float>(), alpha);
+        cluster.setColor(clusterColor);
 
         clusters->addCluster(cluster);
-
     }
 
     events().notifyDatasetDataChanged(clusters);


### PR DESCRIPTION
Some operations on numpy arrays create views instead of copies, see [their docs](https://numpy.org/doc/stable/user/basics.copies.html#how-to-tell-if-the-array-is-a-view-or-a-copy). In those cases we cannot simply copy the data but need to convert the `py::array` first, taking into account the numpy-internal strides.