### PR TITLE
Cluster data

### DIFF
--- a/examples/demo_data_loading.ipynb
+++ b/examples/demo_data_loading.ipynb
@@ -137,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat1 = dh.getItemByID(cat_mv_item.datasetId)\n",
+    "cat1 = dh.getItemByDataID(cat_mv_item.datasetId)\n",
     "cat2 = dh.getItemByIndex([1])\n",
     "cat3 = dh.getItemByName(\"Cat\")\n",
     "\n",

--- a/examples/demo_data_loading.ipynb
+++ b/examples/demo_data_loading.ipynb
@@ -83,7 +83,9 @@
    "id": "3003c7b7-a48f-4156-9287-28ec837f956c",
    "metadata": {},
    "source": [
-    "We push our cat image to ManiVault via the data hierarchy `dh`. We may add `Point` or `Image` data. ManiVault handles images as two data set items, a collection of data points and a description of how they relate to image position. We can `addPointsItem` if we have a simply point data set, but want to use `addImageItem` for automatically creating both ManiVault data items:"
+    "We push our cat image to ManiVault via the data hierarchy `dh`. We may add `Point`, `Image` and `Cluster` data.  ManiVault handles images as two data set items, a collection of data points and a description of how they relate to image position. Similarly, ManiVault considers clusters as a meta-datasets that is connected to point data and stores clusters as sets of indices of the parent points.\n",
+    "\n",
+    "We can `addPointsItem` if we have a simply point data set, but want to use `addImageItem` for automatically creating both ManiVault data items:"
    ]
   },
   {
@@ -228,6 +230,93 @@
    "outputs": [],
    "source": [
     "plt.imshow(cat_roundtrip)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f5d0f2e",
+   "metadata": {},
+   "source": [
+    "Next, let's push a `Cluster` data set to ManiVault. \n",
+    "\n",
+    "We first need to create a list of indices that define our clusters. Here, we simply define the upper and lower half of our image as clusters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74152f5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def split_array(n):\n",
+    "    import numpy as np\n",
+    "    if n % 2 != 0:\n",
+    "        raise ValueError(\"n must be an even number\")\n",
+    "    half = n // 2\n",
+    "    array1 = np.arange(0, half)\n",
+    "    array2 = np.arange(half, n)\n",
+    "    return [array1, array2]\n",
+    "\n",
+    "clusterIndices = split_array(cat_mv_item.numpoints)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31929a37",
+   "metadata": {},
+   "source": [
+    "We need to tell ManiVault which point data set our clusters refer to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c7bda8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster_mv_item = dh.addClusterItem(cat_mv_item.datasetId, clusterIndices, \"CatClusters\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e4e000f",
+   "metadata": {},
+   "source": [
+    "Let's have a look at the data hierarchy again. It mirrors what you see in ManiVault!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e7681da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dh = mvstudio.data.Hierarchy()\n",
+    "print(dh)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9c4cf27",
+   "metadata": {},
+   "source": [
+    "Clusters in ManiVault are automatically assigned names and colors. Optionally, you can set them yourself when calling `addClusterItem(names=[...], colors=[...])` and pass lists of string and numpy arrays respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c55cde64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clusters_retrieved = dh.getItemByIndex([1, 2])\n",
+    "print(f\"First indices of first cluster: {clusters_retrieved.cluster.indices[0][:5]}\")\n",
+    "print(f\"Cluster names: {clusters_retrieved.cluster.names}\")\n",
+    "print(f\"Cluster colors: {clusters_retrieved.cluster.colors}\")"
    ]
   }
  ],

--- a/src/JupyterPlugin/CMakeLists.txt
+++ b/src/JupyterPlugin/CMakeLists.txt
@@ -93,14 +93,30 @@ if (NOT ${EXIT_CODE} EQUAL 0)
     endif()
 endif()
 
-add_custom_target(mvstudio_kernel ALL
+add_custom_target(mvstudio_kernel 
     COMMAND ${Python_EXECUTABLE} -m poetry build --no-interaction --format=wheel
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/mvstudio_kernel
 )
 
-add_custom_target(mvstudio_data ALL
+target_sources(mvstudio_kernel PRIVATE
+    ../mvstudio_kernel/mvstudio/kernel/__init__.py
+    ../mvstudio_kernel/mvstudio/kernel/manager.py
+    ../mvstudio_kernel/mvstudio/kernel/provisioning.py
+)
+
+add_custom_target(mvstudio_data 
     COMMAND ${Python_EXECUTABLE} -m poetry build --no-interaction --format=wheel
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/mvstudio_data
+)
+
+target_sources(mvstudio_data PRIVATE
+    ../mvstudio_data/mvstudio/data/__init__.py
+    ../mvstudio_data/mvstudio/data/cluster.py
+    ../mvstudio_data/mvstudio/data/clusterbase.py
+    ../mvstudio_data/mvstudio/data/factory.py
+    ../mvstudio_data/mvstudio/data/hierarchy.py
+    ../mvstudio_data/mvstudio/data/image.py
+    ../mvstudio_data/mvstudio/data/item.py
 )
 
 add_dependencies(${JUPYTERPLUGIN} mvstudio_kernel mvstudio_data)

--- a/src/JupyterPlugin/CMakeLists.txt
+++ b/src/JupyterPlugin/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(${JUPYTERPLUGIN} PRIVATE pybind11::embed)
 target_link_libraries(${JUPYTERPLUGIN} PRIVATE nlohmann_json::nlohmann_json)
 
 # -----------------------------------------------------------------------------
-# Python MVJupyterPluginManager package
+# Python MVJupyterPluginManager packages
 # -----------------------------------------------------------------------------
 execute_process(
     COMMAND ${Python_EXECUTABLE} -m pip show poetry
@@ -93,15 +93,20 @@ if (NOT ${EXIT_CODE} EQUAL 0)
     endif()
 endif()
 
-message(STATUS "Building the mvstudio_kernel mvstudio_data python packages")
-execute_process(
+add_custom_target(mvstudio_kernel ALL
     COMMAND ${Python_EXECUTABLE} -m poetry build --no-interaction --format=wheel
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/mvstudio_kernel
-    COMMAND_ERROR_IS_FATAL ANY)
-execute_process(
+)
+
+add_custom_target(mvstudio_data ALL
     COMMAND ${Python_EXECUTABLE} -m poetry build --no-interaction --format=wheel
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src/mvstudio_data
-    COMMAND_ERROR_IS_FATAL ANY)
+)
+
+add_dependencies(${JUPYTERPLUGIN} mvstudio_kernel mvstudio_data)
+
+set_target_properties(${JUPYTERPLUGIN} PROPERTIES FOLDER mvstudio_kernel)
+set_target_properties(${JUPYTERPLUGIN} PROPERTIES FOLDER mvstudio_data)
 
 # -----------------------------------------------------------------------------
 # Target installation

--- a/src/JupyterPlugin/XeusInterpreter.cpp
+++ b/src/JupyterPlugin/XeusInterpreter.cpp
@@ -3,6 +3,7 @@
 #include "MVData.h"
 
 #include <iostream>
+#include <stdexcept>
 #include <string>
 
 #include <xeus/xcomm.hpp>
@@ -11,8 +12,8 @@
 #include <xeus-python/xinterpreter.hpp>
 
 #include <pybind11/embed.h>
-#include <pybind11/pybind11.h>
 #include <pybind11/gil.h>
+#include <pybind11/pybind11.h>
 
 #include <QDebug>
 
@@ -39,9 +40,16 @@ void XeusInterpreter::configure_impl()
 
     py::gil_scoped_acquire acquire;
     py::module sys = py::module::import("sys");
-    py::module MVData_module = get_MVData_module();
-    MVData_module.doc() = "Provides access to low level ManiVaultStudio core functions";
-    sys.attr("modules")["mvstudio_core"] = MVData_module;
+
+    try {
+        py::module MVData_module = get_MVData_module();
+        MVData_module.doc() = "Provides access to low level ManiVaultStudio core functions";
+        sys.attr("modules")["mvstudio_core"] = MVData_module;
+    }
+    catch (const std::runtime_error& e)
+    {
+        std::cerr << "MVData modules failed to load: " << e.what() << std::endl;
+    }
 }
 
 // Execute incoming code and publish the result

--- a/src/mvstudio_data/mvstudio/data/clusterbase.py
+++ b/src/mvstudio_data/mvstudio/data/clusterbase.py
@@ -35,11 +35,11 @@ class Cluster:
         return self._names
 
     @property
-    def clusters(self) -> list[np.uint32]:
+    def indices(self) -> list[np.uint32]:
         return self._clusters
     
     @property
-    def col_ids(self) -> list[str]:
+    def cluster_guids(self) -> list[str]:
         return self._ids
     
     @property

--- a/src/mvstudio_data/mvstudio/data/hierarchy.py
+++ b/src/mvstudio_data/mvstudio/data/hierarchy.py
@@ -28,22 +28,22 @@ class Hierarchy:
         """
         self._refresh()
 
-    def getItem(self, guid: str) -> Item:
+    def getItem(self, itemId: str) -> Item:
         """Return the Item corresponding
         to the data hierarchy guid 
         """
         for item in self.children():
-            result = item.getItem(guid)
+            result = item.getItem(itemId)
             if result is not None:
                 return result
         return None
 
-    def getItemByID(self, datasetId: str) -> Item:
+    def getItemByDataID(self, datasetId: str) -> Item:
         """Return the Item corresponding
-        to the data set datasetId 
+        to the data set guid 
         """
         for item in self.children():
-            result = item.getItemByID(datasetId)
+            result = item.getItemByDataID(datasetId)
             if result is not None:
                 return result
         return None
@@ -86,7 +86,7 @@ class Hierarchy:
             name: A name for the point data set
 
         Returns:
-            string: a unique ID for the data item in ManiVault
+            Item|None: Data hierarchy item reference ManiVault
         """
         datasetId = mvstudio_core.add_new_data(data, name)
         if len(datasetId) == 0:
@@ -94,7 +94,7 @@ class Hierarchy:
             return None
         else:
             self._refresh()
-            return self.getItemByID(datasetId)
+            return self.getItemByDataID(datasetId)
         
     def addImageItem(self, data: np.ndarray, name: str) -> Item|None:
         """Add an image data item
@@ -104,7 +104,7 @@ class Hierarchy:
             names: A name for the image item.
 
         Returns:
-            Item|None: a unique ID for the data item in ManiVault
+            Item|None: Data hierarchy item reference ManiVault
         """
         datasetId = mvstudio_core.add_new_image(data, name)
         if len(datasetId) == 0:
@@ -112,7 +112,7 @@ class Hierarchy:
             return None
         else:
             self._refresh()
-            return self.getItemByID(datasetId)
+            return self.getItemByDataID(datasetId)
 
     def addClusterItem(self, parent: str, indices: list[np.ndarray], name: str, **kwargs):
         """Add an cluster data set
@@ -124,7 +124,7 @@ class Hierarchy:
             name: A name for the cluster item
             colors (optional): A list of arrays containing colors of each clusters
         Returns:
-            Item|None: a unique ID for the data item in ManiVault
+            Item|None: Data hierarchy item reference ManiVault
         """
         names = kwargs.get('names', [])
         colors = kwargs.get('colors', [])
@@ -136,7 +136,7 @@ class Hierarchy:
             return None
         else:
             self._refresh()
-            return self.getItemByID(datasetId)
+            return self.getItemByDataID(datasetId)
 
     def children(self) -> Generator[Item, None, None]:
             """Generator for iterating over any children of this DataHierarchyItem.

--- a/src/mvstudio_data/mvstudio/data/hierarchy.py
+++ b/src/mvstudio_data/mvstudio/data/hierarchy.py
@@ -79,12 +79,14 @@ class Hierarchy:
         return item
     
     def addPointsItem(self, data: np.ndarray, name: str) ->Item|None:
-        """Add a points data item and return the corresponding Item 
-            or None if the operation is unsuccessful
+        """Add a points data item
 
         Args: 
             data: The numpy array contain the point data 
-            name: A name for the 
+            name: A name for the point data set
+
+        Returns:
+            string: a unique ID for the data item in ManiVault
         """
         datasetId = mvstudio_core.add_new_data(data, name)
         if len(datasetId) == 0:
@@ -95,14 +97,14 @@ class Hierarchy:
             return self.getItemByID(datasetId)
         
     def addImageItem(self, data: np.ndarray, name: str) -> Item|None:
-        """Add an image data item at the root
+        """Add an image data item
 
         Args:
             data (np.ndarray): A numpy array representing the image
-            namestr (_type_): A string name for the points item.
+            names: A name for the image item.
 
         Returns:
-            Item|None: _description_
+            Item|None: a unique ID for the data item in ManiVault
         """
         datasetId = mvstudio_core.add_new_image(data, name)
         if len(datasetId) == 0:
@@ -112,8 +114,29 @@ class Hierarchy:
             self._refresh()
             return self.getItemByID(datasetId)
 
-    def addClusterItem(self, index: list[int]):
-        pass
+    def addClusterItem(self, parent: str, indices: list[np.ndarray], name: str, **kwargs):
+        """Add an cluster data set
+
+        Args:
+            indices: A list of arrays containing the data indices of each clusters
+            parent: GUID of the parent data set
+            names (optional): A list of string containing names for each cluster
+            name: A name for the cluster item
+            colors (optional): A list of arrays containing colors of each clusters
+        Returns:
+            Item|None: a unique ID for the data item in ManiVault
+        """
+        names = kwargs.get('names', [])
+        colors = kwargs.get('colors', [])
+    
+        datasetId = mvstudio_core.add_new_cluster(parent, indices, names, colors, name)
+
+        if len(datasetId) == 0:
+            warnings.warn("Could not add item", RuntimeWarning)
+            return None
+        else:
+            self._refresh()
+            return self.getItemByID(datasetId)
 
     def children(self) -> Generator[Item, None, None]:
             """Generator for iterating over any children of this DataHierarchyItem.

--- a/src/mvstudio_data/mvstudio/data/image.py
+++ b/src/mvstudio_data/mvstudio/data/image.py
@@ -28,7 +28,7 @@ class ImageMixin:
 class ImageItem(ImageMixin, Item):
     """
     ImageItem adds the Image property the basic Item
-    Images are numpy arrays sahpes to match the image
+    Images are numpy arrays shaped to match the image
     meta data
     """
     def __init__(self, hierarchy, guid_tuple, name, hierarchy_id):

--- a/src/mvstudio_data/mvstudio/data/item.py
+++ b/src/mvstudio_data/mvstudio/data/item.py
@@ -69,28 +69,28 @@ class Item:
             yield self._children[index]
             index += 1
 
-    def getItem(self, guid) -> Self | None:
-        """Return the DataHierarchy Item corresponding
-        to the data hierarchy guid. It can be the current item or a child item.
+    def getItem(self, itemId) -> Self | None:
+        """Return the DataHierarchy Item corresponding to the given
+        hierarchy item ID. It can be the current item or a child item.
         """
-        if self.guid == guid:
+        if self.itemId == itemId:
             return self
         
         for child in self.children():
-            item = child.getItem(guid)
+            item = child.getItem(itemId)
             if item is not None:
                 return item
         return None
     
-    def getItemByID(self, datasetId) -> Self | None:
-        """Return the DataHierarchy Item corresponding
-        to the dataset ID. It can be the current item or a child item.
+    def getItemByDataID(self, datasetId) -> Self | None:
+        """Return the DataHierarchy Item corresponding to the given
+        dataset ID. It can be the current item or a child item.
         """
         if self.datasetId == datasetId:
             return self
         
         for child in self.children():
-            item = child.getItem(datasetId)
+            item = child.getItemByDataID(datasetId)
             if item is not None:
                 return item
         return None
@@ -161,7 +161,7 @@ class Item:
         return self._type
 
     @property
-    def guid(self) -> str:
+    def itemId(self) -> str:
         return self._guid_tuple[0]
     
     @property

--- a/src/mvstudio_data/mvstudio/data/item.py
+++ b/src/mvstudio_data/mvstudio/data/item.py
@@ -128,30 +128,7 @@ class Item:
             if item is not None:
                 break
         return item
-    
-    def addClusterItem(self, cluster: Cluster, cluster_name: str) -> Self | None:
-        """Add a clusteritem as a child of this points item
-
-        Args:
-            cluster (Cluster): A set of clusters that matches the point items in terms of indexes
-
-        Returns:
-            Self | None: An ClusterItem is successful orherwise None
-        """
-        for index_list in cluster.clusters:
-            if not all(c < self.numpoints for c in index_list):
-                return None
         
-        guid = mvstudio_core.add_new_cluster(
-            (cluster.names, cluster.clusters, cluster.colors, cluster.ids),
-            cluster_name,
-            self.datasetId
-        )
-        if not guid:
-            return None
-        
-        return self._hierarchy.getItem(guid)
-    
     @property
     def points(self) -> np.ndarray:
         return mvstudio_core.get_data_for_item(self.datasetId)


### PR DESCRIPTION
Push cluster data from Python to ManiVault.

Also:
- Create targets for building `mvstudio_kernel` and `mvstudio_data` such that they are compiled during build time and not configure time. This allows easier re-compilation when the packages are changed.
- Clearer distinction between dataset ID and hierarchy item ID
- Fail gracefully (not crash) when the `mvstudio_data` cannot create a connection