### PR TITLE
Ask user for interpreter path

### DIFF
--- a/src/JupyterLauncher/CMakeLists.txt
+++ b/src/JupyterLauncher/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SOURCES
     JupyterLauncher.json
     GlobalSettingsAction.h
     GlobalSettingsAction.cpp
+    UserDialogActions.h
+    UserDialogActions.cpp
 )
 
 set (RESOURCES

--- a/src/JupyterLauncher/GlobalSettingsAction.cpp
+++ b/src/JupyterLauncher/GlobalSettingsAction.cpp
@@ -1,8 +1,9 @@
 #include "GlobalSettingsAction.h"
 
+#include "JupyterLauncher.h"
+
 #include <QHBoxLayout>
 #include <QStandardPaths>
-#include <QOperatingSystemVersion>
 
 using namespace mv;
 using namespace mv::gui;
@@ -13,14 +14,7 @@ GlobalSettingsAction::GlobalSettingsAction(QObject* parent, const plugin::Plugin
 {
     _defaultPythonPathAction.setToolTip("A python (.exe on Windows) interpreter for Jupyter Plugin");
 
-    QStringList connectionFilter = { "Connection file (connection.json)" };
-
-    QStringList pythonFilter = {};
-    if (QOperatingSystemVersion::currentType() == QOperatingSystemVersion::Windows)
-        pythonFilter = { "Python interpreter (python*.exe)" };
-    else
-        pythonFilter = { "Python interpreter (python*)" };
-
+    const auto pythonFilter = pythonInterpreterFilters();
     _defaultPythonPathAction.setNameFilters(pythonFilter);
 
     // The add action automatically assigns a settings prefix to _pointSizeAction so there is no need to do this manually

--- a/src/JupyterLauncher/GlobalSettingsAction.cpp
+++ b/src/JupyterLauncher/GlobalSettingsAction.cpp
@@ -10,13 +10,17 @@ using namespace mv::gui;
 
 GlobalSettingsAction::GlobalSettingsAction(QObject* parent, const plugin::PluginFactory* pluginFactory) :
     PluginGlobalSettingsGroupAction(parent, pluginFactory),
-    _defaultPythonPathAction(this, "Python interpreter", "")
+    _defaultPythonPathAction(this, "Python interpreter", ""),
+    _doNotShowAgainButton(this, "Do not show interpreter path picker on start", false)
 {
     _defaultPythonPathAction.setToolTip("A python (.exe on Windows) interpreter for Jupyter Plugin");
+    _doNotShowAgainButton.setToolTip("Whether to show the interpreter path picker on start of the plugin");
 
     const auto pythonFilter = pythonInterpreterFilters();
     _defaultPythonPathAction.setNameFilters(pythonFilter);
+    _defaultPythonPathAction.setUseNativeFileDialog(true);
+    _defaultPythonPathAction.getFilePathAction().setText("Python interpreter");
 
-    // The add action automatically assigns a settings prefix to _pointSizeAction so there is no need to do this manually
     addAction(&_defaultPythonPathAction);
+    addAction(&_doNotShowAgainButton);
 }

--- a/src/JupyterLauncher/GlobalSettingsAction.h
+++ b/src/JupyterLauncher/GlobalSettingsAction.h
@@ -3,6 +3,7 @@
 #include <PluginGlobalSettingsGroupAction.h>
 
 #include <actions/FilePickerAction.h>
+#include <actions/ToggleAction.h>
 
 namespace mv {
     namespace plugin {
@@ -32,7 +33,9 @@ public:
 
 public: // Action getters
     mv::gui::FilePickerAction& getDefaultPythonPathAction() { return _defaultPythonPathAction; }
+    mv::gui::ToggleAction& getDoNotShowAgainButton() { return _doNotShowAgainButton; }
 
 private:
-    mv::gui::FilePickerAction   _defaultPythonPathAction;           /** Default python path */
+    mv::gui::FilePickerAction   _defaultPythonPathAction;       /** Default python path */
+    mv::gui::ToggleAction       _doNotShowAgainButton;          /** Whether to show the interpreter path picker on start */
 };

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -461,11 +461,7 @@ void JupyterLauncher::logProcessOutput()
 
 }
 
-bool JupyterLauncher::validatePythonEnvironment() 
 {
-    // TBD
-    return true;
-}
 
 // The pyversion should correspond to a python major.minor version
 // e.g.

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -57,12 +57,10 @@ JupyterLauncher::JupyterLauncher(const PluginFactory* factory) :
     setObjectName("Jupyter kernel plugin launcher");
 
     QFile jsonFile(_connectionFilePath);
-    if (jsonFile.open(QIODevice::WriteOnly)) {
+    if (jsonFile.open(QIODevice::WriteOnly))
         jsonFile.close();
-    }
-    else {
+    else 
         qWarning() << "JupyterLauncher: Could not create connection file at " << _connectionFilePath;
-    }
 
 }
 
@@ -118,16 +116,10 @@ void JupyterLauncher::setPythonEnv(const QString& version)
 
     auto [isVenv, pythonPath] = getPythonHomePath(pyInterpreter);
 
-    if (isVenv)
-    {
-        // contains "pyvenv.cfg"
+    if (isVenv) // contains "pyvenv.cfg"
         qputenv("VIRTUAL_ENV", pythonPath.toUtf8());
-    }
-    else
-    {
-        // contains python interpreter executable
+    else  // contains python interpreter executable
         qputenv("PYTHONHOME", pythonPath.toUtf8());
-    }
 
     if(QOperatingSystemVersion::currentType() == QOperatingSystemVersion::Windows)
         pythonPath = pythonPath + "/Lib/site-packages";
@@ -135,7 +127,7 @@ void JupyterLauncher::setPythonEnv(const QString& version)
         pythonPath = pythonPath + "/lib/python" + version + "/site-packages";   // TODO: check if we need to remove a . here
 
     // Path to folder with installed packages
-     // PYTHONPATH is essential for xeusinterpreter to load as the xeus_python_shell
+    // PYTHONPATH is essential for xeusinterpreter to load as the xeus_python_shell
     qputenv("PYTHONPATH", QDir::toNativeSeparators(pythonPath).toUtf8());
 }
 

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -409,7 +409,7 @@ void JupyterLauncher::jupyterServerStarted()
     _serverBackgroundTask->setProgress(1.0f);
 }
 
-bool JupyterLauncher::startJupyterServerProcess(const QString& version)
+void JupyterLauncher::startJupyterServerProcess(const QString& version)
 {
     // In order to run python -m jupyter lab and access the MANIVAULT_JUPYTERPLUGIN_CONNECTION_FILE 
     // the env variable must be set in the current process.
@@ -439,8 +439,8 @@ bool JupyterLauncher::startJupyterServerProcess(const QString& version)
     QObject::connect(_serverPollTimer, &QTimer::timeout, [=]() { 
         logProcessOutput(); 
         });
+
     _serverPollTimer->start();
-    return true;
 }
 
 void JupyterLauncher::logProcessOutput()

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -424,7 +424,7 @@ bool JupyterLauncher::startJupyterServerProcess(const QString& version)
     // Setting it in the child QProcess does not work for reasons that are unclear.
     qputenv("MANIVAULT_JUPYTERPLUGIN_CONNECTION_FILE", _connectionFilePath.toUtf8());
 
-    _serverBackgroundTask = new BackgroundTask(nullptr, "JupyterLab Server");
+    _serverBackgroundTask = new BackgroundTask(this, "JupyterLab Server");
     _serverBackgroundTask->setProgressMode(Task::ProgressMode::Manual);
     _serverBackgroundTask->setIdle();
 
@@ -441,7 +441,7 @@ bool JupyterLauncher::startJupyterServerProcess(const QString& version)
     connect(Application::current(), &QCoreApplication::aboutToQuit, this, &JupyterLauncher::shutdownJupyterServer);
 
     _serverProcess.start();
-    _serverPollTimer = new QTimer();
+    _serverPollTimer = new QTimer(this);
     _serverPollTimer->setInterval(20); // poll every 20ms
 
     QObject::connect(_serverPollTimer, &QTimer::timeout, [=]() { 
@@ -453,10 +453,11 @@ bool JupyterLauncher::startJupyterServerProcess(const QString& version)
 
 void JupyterLauncher::logProcessOutput()
 {
-    if (_serverProcess.canReadLine()) {
-        auto output = _serverProcess.readAll();
-        _serverBackgroundTask->setProgressDescription(output);
-    }
+    if (!_serverProcess.canReadLine())
+        return; 
+
+    auto output = _serverProcess.readAll();
+    _serverBackgroundTask->setProgressDescription(output);
 
 }
 

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -46,7 +46,10 @@ public:
     /** This function is called by the core after the view plugin has been created */
     void init() override;
 
-    bool validatePythonEnvironment();
+    // TBD
+    bool validatePythonEnvironment() {
+        return true;
+    }
 
     void loadJupyterPythonKernel(const QString& version);
 

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -103,7 +103,7 @@ public:
     JupyterLauncherFactory();
 
     /** Destructor */
-    ~JupyterLauncherFactory() override {}
+    ~JupyterLauncherFactory() = default;
 
     /** Perform post-construction initialization */
     void initialize() override;

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -7,9 +7,12 @@
 #include <actions/StringAction.h>
 #include <actions/PluginStatusBarAction.h>
 
+#include <QOperatingSystemVersion>
 #include <QProcess>
+#include <QStringList>
 #include <QTimer>
 
+#include <memory>
 #include <utility>
 #include <vector>
 
@@ -17,6 +20,17 @@ using namespace mv::plugin;
 using namespace mv::gui;
 
 class QLabel;
+
+inline QStringList pythonInterpreterFilters()
+{
+    QStringList pythonFilter = {};
+    if (QOperatingSystemVersion::currentType() == QOperatingSystemVersion::Windows)
+        pythonFilter = { "Python interpreter (python*.exe)" };
+    else
+        pythonFilter = { "Python interpreter (python*)" };
+
+    return pythonFilter;
+}
 
 /**
  * Transitive JupyterPlugin Loader

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -1,18 +1,14 @@
 #pragma once
 
 #include <BackgroundTask.h>
-#include <Dataset.h>
-#include <PluginFactory.h>
 #include <ViewPlugin.h>
 
 #include <actions/HorizontalGroupAction.h>
 #include <actions/StringAction.h>
 #include <actions/PluginStatusBarAction.h>
 
-#include <PointData/PointData.h>
-
-#include <QWidget>
 #include <QProcess>
+#include <QTimer>
 
 #include <utility>
 #include <vector>
@@ -82,20 +78,18 @@ private:
     std::pair<bool, QString> getPythonHomePath(const QString& pyInterpreterPath);
     
 private:
-    QHash<QString, PluginFactory*>      _pluginFactories;           /** All loaded plugin factories */
-    std::vector<mv::plugin::Plugin*>    _plugins;                   /** Vector of plugin instances */
-    QString                             _connectionFilePath;
-    QString                             _currentDatasetName;        /** Name of the current dataset */
-    QLabel*                             _currentDatasetNameLabel;   /** Label that show the current dataset name */
-    mv::BackgroundTask*                 _serverBackgroundTask;      /** The background task monitoring the Jupyter Server */
-    QProcess                            _serverProcess;             /** A detached process for running the Jupyter server */
-    QTimer*                             _serverPollTimer;           /** Poll the server process output at a regular interval */
+    QString                 _connectionFilePath;
+    mv::BackgroundTask*     _serverBackgroundTask;      /** The background task monitoring the Jupyter Server */
+    QProcess                _serverProcess;             /** A detached process for running the Jupyter server */
+    QTimer*                 _serverPollTimer;           /** Poll the server process output at a regular interval */
 
 };
 
-/**
- * Jupyter Launcher view plugin factory class
- */
+
+// =============================================================================
+// Factory
+// =============================================================================
+
 class JupyterLauncherFactory : public ViewPluginFactory
 {
     Q_INTERFACES(mv::plugin::ViewPluginFactory mv::plugin::PluginFactory)

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -84,7 +84,7 @@ private:
     bool installKernel(const QString& version);
     bool optionallyInstallMVWheel(const QString& version);
 
-    bool startJupyterServerProcess(const QString& version);
+    void startJupyterServerProcess(const QString& version);
 
     void logProcessOutput();
 

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "UserDialogActions.h"
+
 #include <BackgroundTask.h>
 #include <ViewPlugin.h>
 
@@ -65,7 +67,18 @@ public:
         return true;
     }
 
-    void loadJupyterPythonKernel(const QString& version);
+    // The pyversion should correspond to a python major.minor version
+    // e.g.
+    // "3.11"
+    // "3.12"
+    // There  must be a JupyterPlugin (a kernel provider) that matches the python version for this to work.
+    void launchJupyterKernelAndNotebook(const QString& version);
+
+public: // Global settings
+    // Python interpreter path
+    QString getPythonInterpreterPath();
+
+    bool getShowInterpreterPathDialog();
 
 public slots:
     void jupyterServerError(QProcess::ProcessError error);
@@ -88,17 +101,20 @@ private:
 
     void logProcessOutput();
 
-    // Python interpreter path
-    QString getPythonInterpreterPath();
-
     // Distinguish between python in a regular or conda directory and python in a venv
     std::pair<bool, QString> getPythonHomePath(const QString& pyInterpreterPath);
     
+private slots:
+    void launchJupyterKernelAndNotebookImpl();
+
 private:
-    QString                 _connectionFilePath;
-    mv::BackgroundTask*     _serverBackgroundTask;      /** The background task monitoring the Jupyter Server */
-    QProcess                _serverProcess;             /** A detached process for running the Jupyter server */
-    QTimer*                 _serverPollTimer;           /** Poll the server process output at a regular interval */
+    QString                         _connectionFilePath;
+    QString                         _currentInterpreterVersion;
+
+    mv::BackgroundTask*             _serverBackgroundTask;      /** The background task monitoring the Jupyter Server */
+    QProcess                        _serverProcess;             /** A detached process for running the Jupyter server */
+    QTimer*                         _serverPollTimer;           /** Poll the server process output at a regular interval */
+    std::unique_ptr<LauncherDialog> _launcherDialog;
 
 };
 

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -46,7 +46,7 @@ public:
     /** This function is called by the core after the view plugin has been created */
     void init() override;
 
-     bool validatePythonEnvironment();
+    bool validatePythonEnvironment();
 
     void loadJupyterPythonKernel(const QString& version);
 

--- a/src/JupyterLauncher/UserDialogActions.cpp
+++ b/src/JupyterLauncher/UserDialogActions.cpp
@@ -1,0 +1,35 @@
+#include "UserDialogActions.h"
+
+#include "JupyterLauncher.h"
+
+LauncherDialog::LauncherDialog(QWidget* parent, JupyterLauncher* launcherLauncher) :
+    QDialog(parent),
+    _interpreterFileAction(this, "Python interpreter"),
+    _okButton(this, "Ok"),
+    _doNotShowAgainButton(this, "Do not show again"),
+    _launcherLauncher(launcherLauncher)
+{
+    setWindowTitle(tr("Jupyter Launcher Dialog"));
+    resize(600, 100);
+
+    const auto pythonFilter = pythonInterpreterFilters();
+    _interpreterFileAction.setNameFilters(pythonFilter);
+    _interpreterFileAction.setUseNativeFileDialog(true);
+    _interpreterFileAction.getFilePathAction().setText("Python interpreter");
+    _interpreterFileAction.setFilePath(_launcherLauncher->getPythonInterpreterPath());
+
+    auto* layout = new QGridLayout();
+    layout->setContentsMargins(10, 10, 10, 10);
+
+    QLabel* infoText = new QLabel(this);
+    infoText->setText("Please provide a path to a python interpreter, i.e., the environment you want to use.");
+
+    layout->addWidget(infoText, 0, 0, 1, 5);
+    layout->addWidget(_interpreterFileAction.createWidget(this), 1, 0, 1, 5);
+    layout->addWidget(_okButton.createWidget(this), 2, 4, 1, 1, Qt::AlignRight);
+    layout->addWidget(_doNotShowAgainButton.createWidget(this), 3, 4, 1, 1, Qt::AlignRight);
+
+    setLayout(layout);
+
+    connect(&_okButton, &mv::gui::TriggerAction::triggered, this, &QDialog::accept);
+}

--- a/src/JupyterLauncher/UserDialogActions.h
+++ b/src/JupyterLauncher/UserDialogActions.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <actions/FilePickerAction.h>
+#include <actions/ToggleAction.h>
+#include <actions/TriggerAction.h>
+
+#include <QDialog>
+#include <QObject>
+#include <QWidget>
+
+class JupyterLauncher;
+
+class LauncherDialog : public QDialog
+{
+    Q_OBJECT
+public:
+    LauncherDialog(QWidget* parent, JupyterLauncher* launcherPlugin);
+
+    mv::gui::ToggleAction& getDoNotShowAgainButton() { return _doNotShowAgainButton; }
+
+private:
+    mv::gui::FilePickerAction   _interpreterFileAction;
+    mv::gui::TriggerAction      _okButton;
+    mv::gui::ToggleAction       _doNotShowAgainButton;
+
+    JupyterLauncher*            _launcherLauncher;
+};

--- a/src/JupyterPlugin/JupyterPlugin.cpp
+++ b/src/JupyterPlugin/JupyterPlugin.cpp
@@ -22,17 +22,11 @@ JupyterPlugin::~JupyterPlugin()
     _pKernel->stopKernel();
 }
 
-void JupyterPlugin::setConnectionPath(const QString& connection_path)
-{
-    _connectionFilePath.setFilePath(connection_path);
-}
-
 void JupyterPlugin::init()
 {
     QString jupyter_configFilepath = _connectionFilePath.getFilePath();
     QString pluginVersion = QString::fromStdString(getVersion().getVersionString());
 
-    qDebug() << "JupyterPlugin::init with " << jupyter_configFilepath;
     _pKernel->startKernel(jupyter_configFilepath, pluginVersion);
 }
 

--- a/src/JupyterPlugin/JupyterPlugin.h
+++ b/src/JupyterPlugin/JupyterPlugin.h
@@ -3,8 +3,6 @@
 #include <ViewPlugin.h>
 
 #include <actions/FilePickerAction.h>
-#include <Dataset.h>
-
 #include <memory>
 
 using namespace mv::plugin;
@@ -31,24 +29,20 @@ public:
      * @param factory Pointer to the plugin factory
      */
     JupyterPlugin(const PluginFactory* factory);
-
-    /** Destructor */
     ~JupyterPlugin();
 
-    /** This function is called by the core after the view plugin has been created */
     void init() override;
-
-    void setConnectionPath(const QString& connection_path);
 
 private:
     std::unique_ptr<XeusKernel>     _pKernel;
-
     FilePickerAction                _connectionFilePath;        /** Settings action */
 };
 
-/**
- * Jupyter plugin factory class
- */
+
+// =============================================================================
+// Factory
+// =============================================================================
+
 class JupyterPluginFactory : public ViewPluginFactory
 {
     Q_INTERFACES(mv::plugin::ViewPluginFactory mv::plugin::PluginFactory)

--- a/src/JupyterPlugin/JupyterPlugin.h
+++ b/src/JupyterPlugin/JupyterPlugin.h
@@ -53,10 +53,10 @@ class JupyterPluginFactory : public ViewPluginFactory
 public:
 
     /** Default constructor */
-    JupyterPluginFactory() {}
+    JupyterPluginFactory() = default;
 
     /** Destructor */
-    ~JupyterPluginFactory() override {}
+    ~JupyterPluginFactory() = default;
     
     /** Creates an instance of the example view plugin */
     ViewPlugin* produce() override;


### PR DESCRIPTION
Until now the python interpreter path could only be set in the global settings.

This PR introduces a dialog that asks the the python interpreter path when opening the plugin.

The user can chose to not show this dialog again, a setting that can always be reversed in the global settings.

Drive-by changes:
- Remove unused member variable and methods
- Consistent use of default constructor and destructors
- Some formatting