### PR TITLE
Disable interpreter selection in conda/mamba environment on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,26 @@ print(h)
 
 ### Running on Linux
 
+When using a non-system python interpreter, we have to make sure that the environment variable `LD_PRELOAD` contains the interpreter path that we intend to use in order to [prevent a conflict between the system libstdc++ and the python environment libstdc++](https://www.scivision.dev/conda-python-libstdc-/):
+
+#### Using a Conda environment
+
 Before starting the application (assuming your local environment uses Python 3.12):
 ```
-conda activate my_local_env
+conda activate your_local_env
 CURRENT_PYTHON_PATH=$(find ${CONDA_PREFIX} -name libpython3.12* 2>/dev/null | head -n 1)
-conda env config vars set LD_PRELOAD=$CURRENT_PYTHON_PATH --name my_local_env
-conda deactivate && conda activate my_local_env
+conda env config vars set LD_PRELOAD=$CURRENT_PYTHON_PATH --name your_local_env
+conda deactivate && conda activate your_local_env
+```
+
+#### Using a Mamba environment
+
+Before starting the application (assuming your local environment uses Python 3.12):
+```
+micromamba activate your_local_env
+echo -e "{\"env_vars\": {\"LD_PRELOAD\": \"${CURRENT_PYTHON_PATH}\"}}" >> ${CONDA_PREFIX}/conda-meta/state
+echo -e "LD_PRELOAD=\"${CURRENT_PYTHON_PATH}\"" >> ${CONDA_PREFIX}/conda-meta/state
+micromamba deactivate && micromamba activate your_local_env
 ```
 
 ## Use of Jupyter logo

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ git clone git@github.com:ManiVaultStudio/JupyterPlugin.git
 
 ## Building
 
-1. Setup a python 3.11 environment, 
+1. Setup a python environment (preferably 3.11+):
 - with [venv](https://docs.python.org/3.11/library/venv.html):
 ```bash
 cd YOUR_LOCAL_PATH\AppData\Local\Programs\Python\Python311
@@ -18,7 +18,7 @@ cd YOUR_LOCAL_PATH\AppData\Local\Programs\Python\Python311
 ```
 - with [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) (also works with [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html)):
 ```bash
-conda create -n ManiVaultPythonPluginBuild python=3.11
+conda create -n ManiVaultPythonPluginBuild python=3.11 -y
 ```
 2. Pass `Python_EXECUTABLE` and `ManiVaultDir` to cmake:
     - Define `ManiVault_DIR` pointing to the ManiVault cmake file folder, e.g. `YOUR_LOCAL_PATH/install/cmake/mv`
@@ -33,7 +33,12 @@ This projects builds two ManiVault plugins, a communication bridge `JupyterPlugi
 Additionally two python modules are build `mvstudio_data` and `mvstudio_kernel` that used two pass data between Python and ManiVault. 
 
 It is advisable to use a different environment during building these plugins and during runtime.
-Building the two python modules requires `poetry` which is automatically installed alongside other module dependencies in the `Python_EXECUTABLE` environment.
+Building the two python modules requires `poetry` which is automatically installed in the `Python_EXECUTABLE` environment (see `requirements.txt`).
+`mvstudio_data` and `mvstudio_kernel` have to be installed when first starting the JupyterPlugin in a python environment.
+ManiVault will ask you if this should be performed automatically.
+
+You may build multiple Jupyter Plugins, e.g. `JupyterPlugin311` and `JupyterPlugin312` for different python version. 
+The Jupyter Launcher will list all available plugins during runtime.
 
 ## Dependencies
 
@@ -100,7 +105,7 @@ This plugin kernel based on the Xeus kernel is compatible with Jupyter software.
 
 ## Kernel architecture
 
-The kernel relies on Jupyter-Xeus components to expose a python 3.11 environment. 
+The kernel relies on Jupyter-Xeus components to expose a python environment. 
 
 The architecture of the kernel is based on [Slicer/SlicerJupyter](https://github.com/Slicer/SlicerJupyter). The correspondence is shown in the table below.
 

--- a/src/JupyterLauncher/GlobalSettingsAction.cpp
+++ b/src/JupyterLauncher/GlobalSettingsAction.cpp
@@ -3,6 +3,7 @@
 #include "JupyterLauncher.h"
 
 #include <QHBoxLayout>
+#include <QOperatingSystemVersion>
 #include <QStandardPaths>
 
 using namespace mv;

--- a/src/JupyterLauncher/GlobalSettingsAction.cpp
+++ b/src/JupyterLauncher/GlobalSettingsAction.cpp
@@ -21,6 +21,11 @@ GlobalSettingsAction::GlobalSettingsAction(QObject* parent, const plugin::Plugin
     _defaultPythonPathAction.setUseNativeFileDialog(true);
     _defaultPythonPathAction.getFilePathAction().setText("Python interpreter");
 
+    auto [isConda, pyVersion] = isCondaEnvironmentActive();
+
+    if(QOperatingSystemVersion::currentType() != QOperatingSystemVersion::Windows && isConda)
+        _defaultPythonPathAction.setDisabled(true);
+
     addAction(&_defaultPythonPathAction);
     addAction(&_doNotShowAgainButton);
 }

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -264,7 +264,6 @@ std::pair<bool, QString> isCondaEnvironmentActive()
         return {false, ""};
 
     const QString condaPrefix = QString::fromLocal8Bit(qgetenv("CONDA_PREFIX"));
-    qDebug() << "CONDA_PREFIX exists: " << condaPrefix;
 
     QString pythonInterpreterPath = "";
 
@@ -278,7 +277,7 @@ std::pair<bool, QString> isCondaEnvironmentActive()
     if(givenInterpreterVersion.isEmpty())
         return {false, ""};
 
-    qDebug() << "Python version:" << givenInterpreterVersion.trimmed();
+    qDebug() << "Python version in environment:" << givenInterpreterVersion.trimmed();
 
     return {true, givenInterpreterVersion.trimmed()};
 }
@@ -443,7 +442,7 @@ bool JupyterLauncher::optionallyInstallMVWheel()
     QMessageBox::StandardButton reply = QMessageBox::question(
         nullptr, 
         "Python modules missing", 
-        "mvstudio.kernel and mvstudio.data " + pluginVersion + " are needed in the python environment.\n Do you wish to install it now? ",
+        "mvstudio.kernel " + pluginVersion + " and mvstudio.data " + pluginVersion + " are required for passing data between Python and ManiVault.\nDo you wish to install them now?",
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if (reply == QMessageBox::Yes) {
         auto MVWheelPath = QCoreApplication::applicationDirPath() + "/PluginDependencies/JupyterLauncher/py/";

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -277,8 +277,6 @@ std::pair<bool, QString> isCondaEnvironmentActive()
     if(givenInterpreterVersion.isEmpty())
         return {false, ""};
 
-    qDebug() << "Python version in environment:" << givenInterpreterVersion.trimmed();
-
     return {true, givenInterpreterVersion.trimmed()};
 }
 

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -32,6 +32,8 @@ inline QStringList pythonInterpreterFilters()
     return pythonFilter;
 }
 
+std::pair<bool, QString> isCondaEnvironmentActive();
+
 /**
  * Transitive JupyterPlugin Loader
  *
@@ -66,9 +68,7 @@ public:
     }
 
     // The pyversion should correspond to a python major.minor version
-    // e.g.
-    // "3.11"
-    // "3.12"
+    // e.g. "3.11", "3.12"
     // There  must be a JupyterPlugin (a kernel provider) that matches the python version for this to work.
     void launchJupyterKernelAndNotebook(const QString& version);
 

--- a/src/JupyterLauncher/UserDialogActions.cpp
+++ b/src/JupyterLauncher/UserDialogActions.cpp
@@ -2,6 +2,7 @@
 
 #include "JupyterLauncher.h"
 
+#include <QOperatingSystemVersion>
 #include <QWidget>
 
 LauncherDialog::LauncherDialog(QWidget* parent, JupyterLauncher* launcherLauncher) :

--- a/src/JupyterLauncher/UserDialogActions.cpp
+++ b/src/JupyterLauncher/UserDialogActions.cpp
@@ -22,6 +22,25 @@ LauncherDialog::LauncherDialog(QWidget* parent, JupyterLauncher* launcherLaunche
     _interpreterFileAction.getFilePathAction().setText("Python interpreter");
     _interpreterFileAction.setFilePath(_launcherLauncher->getPythonInterpreterPath());
 
+    auto [isConda, pyVersion] = isCondaEnvironmentActive();
+
+    auto interpreterFileActionWidget =_interpreterFileAction.createWidget(this);
+
+    if(QOperatingSystemVersion::currentType() != QOperatingSystemVersion::Windows && isConda)
+    {
+        const QString pythonInterpreterPath = QString::fromLocal8Bit(qgetenv("CONDA_PREFIX")) + "/bin/python3";
+
+        _launcherLauncher->setPythonInterpreterPath(pythonInterpreterPath);
+        _interpreterFileAction.setFilePath(pythonInterpreterPath);
+        _interpreterFileAction.setToolTip("On UNIX systems in a conda/mamba environment you cannot switch the python interpreter");
+        interpreterFileActionWidget->setDisabled(true);
+
+        qDebug() << "JupyterLauncher: Disable python environment selection";
+    }
+    else
+        _interpreterFileAction.setToolTip("Select the Python interpreter...");
+
+
     _doNotShowAgainButton.setToolTip("You can always change this\nback in the global settings.");
 
     _moduleInfoText.setDefaultWidgetFlags(mv::gui::StringAction::WidgetFlag::Label);
@@ -57,7 +76,7 @@ LauncherDialog::LauncherDialog(QWidget* parent, JupyterLauncher* launcherLaunche
     infoText->setText("Please provide a path to a python interpreter, i.e., the environment you want to use.");
 
     layout->addWidget(infoText, row, 0, 1, 5);
-    layout->addWidget(_interpreterFileAction.createWidget(this), ++row, 0, 1, 5);
+    layout->addWidget(interpreterFileActionWidget, ++row, 0, 1, 5);
     layout->addWidget(_moduleInfoGroupsWidget, ++row, 0, 1, 5);
     layout->addWidget(_okButton.createWidget(this), ++row, 4, 1, 1, Qt::AlignRight);
     layout->addWidget(_doNotShowAgainButton.createWidget(this), ++row, 4, 1, 1, Qt::AlignRight);

--- a/src/JupyterPlugin/XeusInterpreter.cpp
+++ b/src/JupyterPlugin/XeusInterpreter.cpp
@@ -62,11 +62,15 @@ void XeusInterpreter::configure_impl()
             std::string environmentName = QDir(condaPrefixPath.absoluteFilePath()).dirName().toStdString();
             std::string pyVersion = std::to_string(pythonVersionMajor) + "." + std::to_string(pythonVersionMinor);
 
-            std::cerr << "If you are using a conda/mamba environment, setting LD_PRELOAD before restarting the application might help:\n";
+            std::cerr << "If you are using a conda environment, setting LD_PRELOAD before restarting the application might help:\n";
             std::cerr << "   conda activate " + environmentName + "\n";
             std::cerr << "   CURRENT_PYTHON_PATH=$(find ${CONDA_PREFIX} -name libpython" + pyVersion + "* 2>/dev/null | head -n 1)\n";
             std::cerr << "   conda env config vars set LD_PRELOAD=$CURRENT_PYTHON_PATH --name " + environmentName + "\n";
             std::cerr << "   conda deactivate && conda activate " + environmentName + "\n";
+            std::cerr << "\n";
+            std::cerr << "If you are using a mamba environment, setting LD_PRELOAD has to be done slightly differently:\n";
+            std::cerr << '   echo -e "{\\"env_vars\\": {\\"LD_PRELOAD\\": \\"${CURRENT_PYTHON_PATH}\\"}}" >> ${CONDA_PREFIX}/conda-meta/state\n';
+            std::cerr << "   micromamba deactivate && micromamba activate " + environmentName + "\n";
             std::cerr << std::endl;
         }
         throw std::runtime_error("Cannot start notebook");

--- a/src/JupyterPlugin/XeusInterpreter.cpp
+++ b/src/JupyterPlugin/XeusInterpreter.cpp
@@ -49,6 +49,7 @@ void XeusInterpreter::configure_impl()
     catch (const std::runtime_error& e)
     {
         std::cerr << "MVData modules failed to load: " << e.what() << std::endl;
+        throw std::runtime_error("Required python modules not available");
     }
     catch (...) 
     {
@@ -68,7 +69,9 @@ void XeusInterpreter::configure_impl()
             std::cerr << "   conda deactivate && conda activate " + environmentName + "\n";
             std::cerr << std::endl;
         }
+        throw std::runtime_error("Cannot start notebook");
     }
+
 }
 
 void XeusInterpreter::execute_request_impl(send_reply_callback cb,

--- a/src/JupyterPlugin/XeusInterpreter.cpp
+++ b/src/JupyterPlugin/XeusInterpreter.cpp
@@ -15,6 +15,9 @@
 #define slots Q_SLOTS
 
 #include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QOperatingSystemVersion>
 
 namespace py = pybind11;
 
@@ -46,6 +49,25 @@ void XeusInterpreter::configure_impl()
     catch (const std::runtime_error& e)
     {
         std::cerr << "MVData modules failed to load: " << e.what() << std::endl;
+    }
+    catch (...) 
+    {
+        std::cerr << "Unable to start jupyter notebook..." << std::endl;
+
+        if(QOperatingSystemVersion::currentType() != QOperatingSystemVersion::Windows && qEnvironmentVariableIsSet("CONDA_PREFIX"))
+        {
+            const QString condaPrefix = QString::fromLocal8Bit(qgetenv("CONDA_PREFIX"));
+            QFileInfo condaPrefixPath(condaPrefix);
+            std::string environmentName = QDir(condaPrefixPath.absoluteFilePath()).dirName().toStdString();
+            std::string pyVersion = std::to_string(pythonVersionMajor) + "." + std::to_string(pythonVersionMinor);
+
+            std::cerr << "If you are using a conda/mamba environment, setting LD_PRELOAD before restarting the application might help:\n";
+            std::cerr << "   conda activate " + environmentName + "\n";
+            std::cerr << "   CURRENT_PYTHON_PATH=$(find ${CONDA_PREFIX} -name libpython" + pyVersion + "* 2>/dev/null | head -n 1)\n";
+            std::cerr << "   conda env config vars set LD_PRELOAD=$CURRENT_PYTHON_PATH --name " + environmentName + "\n";
+            std::cerr << "   conda deactivate && conda activate " + environmentName + "\n";
+            std::cerr << std::endl;
+        }
     }
 }
 

--- a/src/JupyterPlugin/XeusInterpreter.cpp
+++ b/src/JupyterPlugin/XeusInterpreter.cpp
@@ -69,7 +69,7 @@ void XeusInterpreter::configure_impl()
             std::cerr << "   conda deactivate && conda activate " + environmentName + "\n";
             std::cerr << "\n";
             std::cerr << "If you are using a mamba environment, setting LD_PRELOAD has to be done slightly differently:\n";
-            std::cerr << '   echo -e "{\\"env_vars\\": {\\"LD_PRELOAD\\": \\"${CURRENT_PYTHON_PATH}\\"}}" >> ${CONDA_PREFIX}/conda-meta/state\n';
+            std::cerr << "   echo -e \"{\\\"env_vars\\\": {\\\"LD_PRELOAD\\\": \\\"${CURRENT_PYTHON_PATH}\\\"}}\" >> ${CONDA_PREFIX}/conda-meta/state\n";
             std::cerr << "   micromamba deactivate && micromamba activate " + environmentName + "\n";
             std::cerr << std::endl;
         }

--- a/src/JupyterPlugin/XeusKernel.cpp
+++ b/src/JupyterPlugin/XeusKernel.cpp
@@ -27,15 +27,21 @@ void XeusKernel::startKernel(const QString& connection_path, const QString& plug
     std::unique_ptr<XeusInterpreter>        interpreter = std::make_unique<XeusInterpreter>(pluginVersion);
     std::unique_ptr<xeus::xhistory_manager> history     = xeus::make_in_memory_history_manager();
 
-    m_kernel = std::make_unique<xeus::xkernel>(
-        /*config: noy used here */
-        /*user_name*/ xeus::get_user_name(),
-        /*context*/ std::move(context),
-        /*interpreter*/ std::move(interpreter),
-        /*server_builder*/ make_XeusServer,
-        /*history_manager*/ std::move(history),
-        /*logger*/ nullptr
-    );
+    try {
+        m_kernel = std::make_unique<xeus::xkernel>(
+            /*config: noy used here */
+            /*user_name*/ xeus::get_user_name(),
+            /*context*/ std::move(context),
+            /*interpreter*/ std::move(interpreter),
+            /*server_builder*/ make_XeusServer,
+            /*history_manager*/ std::move(history),
+            /*logger*/ nullptr
+        );
+    } catch (const std::exception& ex) {
+        qDebug() << "Cannot create xeus kernel: " << ex.what();
+        m_kernel.reset();
+        return;
+    }
 
     // Save the config that was generated
     const auto& set_config = m_kernel->get_config();


### PR DESCRIPTION
- Automatically sets interpreter on linux with conda/mamba
- Helpful error messages
- Fail gracefully, i.e. catch unsuccessful Xeus init
- Extend README with mamba and multiple python versions info 