### PR TITLE
Access data properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 # Jupyter Plugins
 # -----------------------------------------------------------------------------
 PROJECT("JupyterPlugins"
-    VERSION 0.2.0
+    VERSION 0.3.0
     DESCRIPTION "Jupyter plugin for ManiVault"
     LANGUAGES CXX)
 

--- a/src/JupyterLauncher/JupyterLauncher.json
+++ b/src/JupyterLauncher/JupyterLauncher.json
@@ -1,5 +1,5 @@
 {
     "name": "Jupyter Launcher",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "dependencies": [ ]
 }

--- a/src/JupyterPlugin/CMakeLists.txt
+++ b/src/JupyterPlugin/CMakeLists.txt
@@ -150,7 +150,7 @@ install(FILES
     ${PROJECT_SOURCE_DIR}/src/mvstudio_data/dist/mvstudio_data-${PROJECT_VERSION}-py3-none-any.whl 
     ${PROJECT_SOURCE_DIR}/src/mvstudio_kernel/dist/mvstudio_kernel-${PROJECT_VERSION}-py3-none-any.whl 
     DESTINATION PluginDependencies/JupyterLauncher/py 
-    COMPONENT PLUGIN
+    COMPONENT PYTHONWHEELS
 )
 
 install(FILES 
@@ -165,6 +165,14 @@ add_custom_command(TARGET ${JUPYTERPLUGIN} POST_BUILD
     --install ${CMAKE_CURRENT_BINARY_DIR}
     --config $<CONFIGURATION>
     --component PLUGIN
+    --prefix ${ManiVault_INSTALL_DIR}/$<CONFIGURATION>
+)
+
+add_custom_command(TARGET ${JUPYTERPLUGIN} POST_BUILD
+    COMMAND "${CMAKE_COMMAND}"
+    --install ${CMAKE_CURRENT_BINARY_DIR}
+    --config $<CONFIGURATION>
+    --component PYTHONWHEELS
     --prefix ${ManiVault_INSTALL_DIR}/$<CONFIGURATION>
 )
 

--- a/src/JupyterPlugin/JupyterPlugin.json
+++ b/src/JupyterPlugin/JupyterPlugin.json
@@ -1,5 +1,5 @@
 {
     "name": "Jupyter Plugin",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "dependencies": [ "Points", "Images", "Cluster" ]
 }

--- a/src/mvstudio_data/mvstudio/data/item.py
+++ b/src/mvstudio_data/mvstudio/data/item.py
@@ -1,5 +1,5 @@
 import mvstudio_core
-from typing import Generator, Self
+from typing import Generator, Self, Any
 import numpy as np
 import numpy.typing as npt
 from enum import Enum
@@ -173,6 +173,15 @@ class Item:
     def numpoints(self) -> int:
         """Return the numper of points"""
         return mvstudio_core.get_item_numpoints(self.datasetId)
+
+    @property
+    def properties(self) -> list[str]:
+        """Return the names of available properties"""
+        return mvstudio_core.get_item_properties(self.datasetId)
+
+    def getProperty(self, name : str) -> Any:
+        """Return the property with a given name"""
+        return mvstudio_core.get_item_property(self.datasetId, name)
 
     def __str__(self) -> str:
         children_strs = [f'{"  "*(len(self._hierarchy_id)-1)}Item id: {self._hierarchy_id}, dataset id: {self.datasetId}, display name: {self.name}, type: {self.type}']

--- a/src/mvstudio_data/pyproject.toml
+++ b/src/mvstudio_data/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mvstudio_data"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Baldur van Lew <b.van_lew@lumc.nl>"]
 readme = "README.md"
 description = 'Python data model for the ManiVaultStudio (mvstudio)'

--- a/src/mvstudio_kernel/pyproject.toml
+++ b/src/mvstudio_kernel/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mvstudio_kernel"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Baldur van Lew <b.van_lew@lumc.nl>"]
 readme = "README.md"
 description = 'Python kernel manager for the ManiVaultStudio (mvstudio)'

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterplugin",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "dependencies": [
         {
             "name": "openssl",


### PR DESCRIPTION
Example use the [CombineDataPlugin](https://github.com/ManiVaultStudio/CombineDataPlugin) adds some properties to a newly combined dataset, which we might want to inspect now:

```python
combi = dh.getItemByDataID("ab453af5-735a-4594-b4e0-d162afd696ec")
print(f"combi properties: {combi.properties}")

propIDs = combi.getProperty("Combined Dataset IDs")
print(f"combi prop IDs: {propIDs}")

propOfs = combi.getProperty("Combined Dataset Offsets")
print(f"combi prop Offsets: {propOfs}")
````