### PR TITLE
update dependencies 2025-04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Clone vcpkg
         run: |
           cd ${{ github.workspace }}
-          git clone --branch 2025.01.13 --single-branch https://github.com/microsoft/vcpkg.git
+          git clone --branch 2025.04.09 --single-branch https://github.com/microsoft/vcpkg.git
 
       # Bootstrap vcpkg
       - name: Bootstrap vcpkg (Windows)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ include(CMakePackageConfigHelpers)
 # xeus depends on: nlohmann_json
 # xeus-zmq depends on: xeus, ZeroMQ (libzmq), cppzmq, OpenSSL, and nlohmann_json
 # xeus-python depends on: xeus-zmq, pybind11, pybind11_json and nlohmann_json
-set(xeus_VERSION "5.1.1")
+set(xeus_VERSION "5.2.1")
 set(nlohmann_json_VERSION "v3.11.3")
 set(libzmq_VERSION "v4.3.5")
 set(cppzmq_VERSION "v4.10.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ include(CMakePackageConfigHelpers)
 # xeus-zmq depends on: xeus, ZeroMQ (libzmq), cppzmq, OpenSSL, and nlohmann_json
 # xeus-python depends on: xeus-zmq, pybind11, pybind11_json and nlohmann_json
 set(xeus_VERSION "5.2.1")
-set(nlohmann_json_VERSION "v3.11.3")
+set(nlohmann_json_VERSION "v3.12.0")
 set(libzmq_VERSION "v4.3.5")
 set(cppzmq_VERSION "v4.10.0")
 set(xeus-zmq_VERSION "3.1.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(libzmq_VERSION "v4.3.5")
 set(cppzmq_VERSION "v4.10.0")
 set(xeus-zmq_VERSION "3.1.0")
 set(pybind11_VERSION "v2.13.6")
-set(pybind11_json_VERSION "0.2.14")
+set(pybind11_json_VERSION "0.2.15")
 set(xeus-python_VERSION "0.17.2")
 
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ set(cppzmq_VERSION "v4.10.0")
 set(xeus-zmq_VERSION "3.1.0")
 set(pybind11_VERSION "v2.13.6")
 set(pybind11_json_VERSION "0.2.15")
-set(xeus-python_VERSION "0.17.2")
+set(xeus-python_VERSION "0.17.4")
 
 find_package(Qt6 COMPONENTS Widgets WebEngineWidgets REQUIRED)
 find_package(ManiVault COMPONENTS Core PointData ClusterData ImageData CONFIG QUIET)

--- a/src/JupyterPlugin/XeusKernel.cpp
+++ b/src/JupyterPlugin/XeusKernel.cpp
@@ -29,7 +29,7 @@ void XeusKernel::startKernel(const QString& connection_path, const QString& plug
 
     try {
         m_kernel = std::make_unique<xeus::xkernel>(
-            /*config: noy used here */
+            /*config: not used here */
             /*user_name*/ xeus::get_user_name(),
             /*context*/ std::move(context),
             /*interpreter*/ std::move(interpreter),

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,8 +7,8 @@
             "platform": "windows"
         }
     ],
-    "builtin-baseline":"6f29f12e82a8293156836ad81cc9bf5af41fe836",
+    "builtin-baseline":"ce613c41372b23b1f51333815feb3edd87ef8a8b",
     "overrides": [
-        { "name": "openssl", "version": "3.4.0#1" }
+        { "name": "openssl", "version": "3.5.0#0" }
     ]
 }


### PR DESCRIPTION
Several minor and patch version updates:
- `jupyter-xeus/xeus` to `5.2.1` from `5.1.1`
- `xeus-python` to `0.17.4` from `0.17.2`
- `nlohmann_json` to `3.12.0` from `3.11.3`
- `pybind11_json` to `0.2.15` from `0.2.14`
- `openssl` to `3.5.0` from `3.4.0`