### PR TITLE
Add description field to Python scripts

### DIFF
--- a/docs/Python_scripts_for_ManiVault.md
+++ b/docs/Python_scripts_for_ManiVault.md
@@ -135,6 +135,7 @@ With a corresponding ManiVault extension files, a `example_script.json`:
     "script": "example_script.py",
     "name": "Example script",
     "type": "Loader",
+    "description": "Load data of arbitrary shape and form",
     "requirements": "example_script_requirements.txt",
     "arguments": [
         {

--- a/docs/Python_scripts_for_ManiVault.md
+++ b/docs/Python_scripts_for_ManiVault.md
@@ -30,6 +30,7 @@ Fields of the extension file:
 - `name` (required): Name of the script as to be displayed in ManiVault
 - `type` (required): Corresponding to ManiVault's plugin types, i.e., "Loader", "Writer", "Analysis", "transform" and "View"
 - `requirements` (optional): Name of a requirements file
+- `description` (optional): Description of what the script does. Will be displayed in the user-input dialog
 - `input-datatypes` (optional): ManiVault dataset types to which the script might apply (_currently not used_)
 - `arguments` (optional): List of arguments passed to the script. Used to automatically populate a user dialog
     - `name` (required): Name of the argument as shown in the user dialog

--- a/examples/scripts/write_image_as_png.json
+++ b/examples/scripts/write_image_as_png.json
@@ -3,6 +3,7 @@
     "name": "Export image as PNG",
     "type": "Writer",
     "requirements": "write_image_as_png_requirements.txt",
+    "description": "Writes an image as a PNG file to disk",
     "input-datatypes" : ["Images"],
     "arguments": [
         {

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -911,9 +911,10 @@ void JupyterLauncher::addPythonScripts()
         QDir dir(fileInfo.absolutePath());
 
         // check requirements
-        if (json.contains("requirements")) {
+        if (json.contains("requirements") && json["requirements"].isString()) {
 
             QString requirementsFilePath    = dir.filePath(json["requirements"].toString());
+            qDebug() << "Checking and installing requirements for: " << requirementsFilePath;
             bool requirementsAreInstalled   = checkRequirements(requirementsFilePath);
 
             if (!requirementsAreInstalled) {

--- a/src/JupyterLauncher/ScriptDialogAction.cpp
+++ b/src/JupyterLauncher/ScriptDialogAction.cpp
@@ -41,9 +41,10 @@ ScriptDialog::ScriptDialog(QWidget* parent, const QJsonObject json, const QStrin
     if (json.contains("description") && json["description"].isString()) {
         QString description = json["description"].toString();
 
-        auto widgetAction = _argumentActions.emplace_back(new mv::gui::StringAction(this, "description"));
+        auto widgetAction = _argumentActions.emplace_back(new mv::gui::StringAction(this, "Description"));
         auto stringAction = static_cast<mv::gui::StringAction*>(widgetAction);
         stringAction->setDefaultWidgetFlags(mv::gui::StringAction::WidgetFlag::Label);
+        stringAction->setString(description);
         layout->addWidget(widgetAction->createLabelWidget(this), ++row, 0, 1, 1);
         layout->addWidget(widgetAction->createWidget(this), row, 1, 1, -1);
     }

--- a/src/JupyterLauncher/ScriptDialogAction.cpp
+++ b/src/JupyterLauncher/ScriptDialogAction.cpp
@@ -38,6 +38,16 @@ ScriptDialog::ScriptDialog(QWidget* parent, const QJsonObject json, const QStrin
     layout->setContentsMargins(10, 10, 10, 10);
     int row = 0;
 
+    if (json.contains("description") && json["description"].isString()) {
+        QString description = json["description"].toString();
+
+        auto widgetAction = _argumentActions.emplace_back(new mv::gui::StringAction(this, "description"));
+        auto stringAction = static_cast<mv::gui::StringAction*>(widgetAction);
+        stringAction->setDefaultWidgetFlags(mv::gui::StringAction::WidgetFlag::Label);
+        layout->addWidget(widgetAction->createLabelWidget(this), ++row, 0, 1, 1);
+        layout->addWidget(widgetAction->createWidget(this), row, 1, 1, -1);
+    }
+
     if (json.contains("arguments") && json["arguments"].isArray()) {
         QJsonArray arguments = json["arguments"].toArray();
 


### PR DESCRIPTION
Adds an optional `description` field to the script meta data.

![image](https://github.com/user-attachments/assets/3279a950-fc5b-4438-8573-e6f93951e02d)
