### PR TITLE
Use scripting manager for UI placement of script entries

### DIFF
--- a/docs/Python_scripts_for_ManiVault.md
+++ b/docs/Python_scripts_for_ManiVault.md
@@ -28,7 +28,7 @@ When executing a script, a user dialog is automatically populated with input fie
 Fields of the extension file:
 - `script` (required): Name of the python script file
 - `name` (required): Name of the script as to be displayed in ManiVault
-- `type` (required): Corresponding to ManiVault's plugin types, i.e., "Loader", "Writer", "Analysis", "transform" and "View"
+- `type` (required): Corresponding to ManiVault's plugin types, i.e., "Loader", "Writer", "Analysis", "Transformation" and "View"
 - `requirements` (optional): Name of a requirements file
 - `description` (optional): Description of what the script does. Will be displayed in the user-input dialog
 - `input-datatypes` (optional): ManiVault dataset types to which the script might apply (_currently not used_)

--- a/docs/Python_scripts_for_ManiVault.md
+++ b/docs/Python_scripts_for_ManiVault.md
@@ -31,7 +31,7 @@ Fields of the extension file:
 - `type` (required): Corresponding to ManiVault's plugin types, i.e., "Loader", "Writer", "Analysis", "Transformation" and "View"
 - `requirements` (optional): Name of a requirements file
 - `description` (optional): Description of what the script does. Will be displayed in the user-input dialog
-- `input-datatypes` (optional): ManiVault dataset types to which the script might apply (_currently not used_)
+- `input-datatypes` (optional, but recommended): ManiVault dataset types to which the script might apply (used for placing script entries in UI)
 - `arguments` (optional): List of arguments passed to the script. Used to automatically populate a user dialog
     - `name` (required): Name of the argument as shown in the user dialog
     - `argument` (required): Command line argument name, e.g. "--input-file-image"

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -849,13 +849,6 @@ void JupyterLauncher::addPythonScripts()
     }
 
     // Add UI entries for the scripts
-    auto statusBarAction = new StatusBarAction(this, "Python Scripts " + _selectedInterpreterVersion, mv::util::StyledIcon("python"));
-    auto statusBar = Application::getMainWindow()->statusBar();
-
-    int numberOfPermanentWidgets = statusBar->findChildren<QWidget*>(Qt::FindDirectChildrenOnly).count();
-    int widetIndex = std::max(0, numberOfPermanentWidgets - 1);
-    statusBar->insertPermanentWidget(widetIndex, statusBarAction->createWidget(Application::getMainWindow()), statusBarAction->getStretch());
-
     auto checkRequirements = [](const QString& requirementsFilePath) -> bool {
         QFileInfo requirementsFileInfo(requirementsFilePath);
 
@@ -864,7 +857,7 @@ void JupyterLauncher::addPythonScripts()
             return false;
         }
 
-        QStringList params              = { "-m", "pip", "install", "-r", requirementsFilePath, "--dry-run" };
+        QStringList params = { "-m", "pip", "install", "-r", requirementsFilePath, "--dry-run" };
 
 #ifdef NDEBUG
         bool verbose = false;
@@ -875,7 +868,7 @@ void JupyterLauncher::addPythonScripts()
         return runPythonCommand(params, verbose);
         };
 
-    uint32_t numLoadedScripts = 0;
+    uint32_t numLoadedScripts   = 0;
 
     for (const auto& scriptDescriptor : scriptDescriptors) {
         QFile file(scriptDescriptor);

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -923,9 +923,10 @@ void JupyterLauncher::addPythonScripts()
 
         const QString scriptPath = dir.filePath(json["script"].toString());
         const QString scriptName = json["name"].toString();
+        const QString scriptType = json["type"].toString();
 
         mv::Datasets dummy = {};
-        _scriptTriggerActions.push_back(std::make_shared<PythonScript>(scriptName, util::Script::Type::Writer, scriptPath, dummy, _selectedInterpreterVersion, json, this, nullptr));
+        _scriptTriggerActions.push_back(std::make_shared<PythonScript>(scriptName, mv::util::Script::getTypeEnum(scriptType), scriptPath, dummy, _selectedInterpreterVersion, json, this, nullptr));
 
         numLoadedScripts++;
     }
@@ -935,9 +936,11 @@ void JupyterLauncher::addPythonScripts()
 
 mv::gui::ScriptTriggerActions JupyterLauncher::getScriptTriggerActions(const mv::Datasets& datasets) const {
     ScriptTriggerActions scriptTriggerActions;
-
-    for(auto& scriptTriggerAction: _scriptTriggerActions)
-        scriptTriggerActions << new ScriptTriggerAction(nullptr, scriptTriggerAction, "Test");
+    
+    for (auto& scriptTriggerAction : _scriptTriggerActions) {
+        auto menuLocation = QString("%1/%2").arg(mv::util::Script::getTypeName(scriptTriggerAction->getType()), scriptTriggerAction->getTitle());
+        scriptTriggerActions << new ScriptTriggerAction(nullptr, scriptTriggerAction, menuLocation);
+    }
 
     return scriptTriggerActions;
 }

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -784,15 +784,23 @@ bool JupyterLauncher::initPython(bool activateXeus)
     return true;
 }
 
-void JupyterLauncher::launchJupyterKernelAndNotebook(const QString& version)
+bool JupyterLauncher::initLauncher(const QString& version, int mode)
 {
     _selectedInterpreterVersion = version;
 
     if (getShowInterpreterPathDialog()) {
-        _launcherDialog->setMode(0);
+        _launcherDialog->setMode(mode);
         _launcherDialog->show();                // by default ask user for python path
-        return;
+        return false;
     }
+
+    return true;
+}
+
+void JupyterLauncher::launchJupyterKernelAndNotebook(const QString& version)
+{
+    if (!initLauncher(version, /*mode*/ 0))
+        return;
 
     createPythonPluginAndStartNotebook();   // open notebook immediately if user has set do-not-show-dialog option
 }
@@ -809,13 +817,8 @@ void JupyterLauncher::createPythonPluginAndStartNotebook()
 
 void JupyterLauncher::initPythonScripts(const QString& version)
 {
-    _selectedInterpreterVersion = version;
-
-    if (getShowInterpreterPathDialog()) {
-        _launcherDialog->setMode(1);
-        _launcherDialog->show();                // by default ask user for python path
+    if (!initLauncher(version, /*mode*/ 1))
         return;
-    }
 
     addPythonScripts();
 }

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -868,7 +868,8 @@ void JupyterLauncher::addPythonScripts()
         return runPythonCommand(params, verbose);
         };
 
-    uint32_t numLoadedScripts   = 0;
+    uint32_t numLoadedScripts = 0;
+    _scriptTriggerActions.clear();
 
     for (const auto& scriptDescriptor : scriptDescriptors) {
         QFile file(scriptDescriptor);
@@ -923,7 +924,6 @@ void JupyterLauncher::addPythonScripts()
         const QString scriptPath = dir.filePath(json["script"].toString());
         const QString scriptName = json["name"].toString();
 
-        _scriptTriggerActions.clear();
         mv::Datasets dummy = {};
         _scriptTriggerActions.push_back(std::make_shared<PythonScript>(scriptName, util::Script::Type::Writer, scriptPath, dummy, _selectedInterpreterVersion, json, this, nullptr));
 

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -903,7 +903,7 @@ void JupyterLauncher::addPythonScripts()
 
         const std::vector<QString> requiredEntries = { "script", "name", "type"};
 
-        if (!std::all_of(requiredEntries.begin(), requiredEntries.end(), [&json](const QString& entry) { return json.contains(entry); })) {
+        if (!std::all_of(requiredEntries.begin(), requiredEntries.end(), [&json](const QString& entry) { return json.contains(entry) && json[entry].isString(); })) {
             qWarning() << "Does not contain all required entries: " << scriptDescriptor;
             qWarning().noquote() << document.toJson(QJsonDocument::Indented);
             continue;

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -927,20 +927,25 @@ void JupyterLauncher::addPythonScripts()
         const QString scriptPath = dir.filePath(json["script"].toString());
         const QString scriptName = json["name"].toString();
 
-        auto scriptTrigger = new TriggerAction(this, scriptName);
-        connect(scriptTrigger, &TriggerAction::triggered, this, [this, json, scriptPath]() {
-            // TODO: only open dialog if necessary, i.e. if user input is needed
-            auto scriptDialog = new ScriptDialog(nullptr, json, scriptPath, _selectedInterpreterVersion, this);
-            connect(scriptDialog, &QDialog::finished, scriptDialog, &QObject::deleteLater);
-            scriptDialog->show();
-            });
+        _scriptTriggerActions.clear();
+        mv::Datasets dummy = {};
+        _scriptTriggerActions.push_back(std::make_shared<PythonScript>(scriptName, util::Script::Type::Writer, scriptPath, dummy, _selectedInterpreterVersion, json, this, nullptr));
 
-        statusBarAction->addMenuAction(scriptTrigger);
         numLoadedScripts++;
     }
 
     qDebug().noquote() << QString("JupyterLauncher: Loaded %1 scripts").arg(numLoadedScripts);
 }
+
+mv::gui::ScriptTriggerActions JupyterLauncher::getScriptTriggerActions(const mv::Datasets& datasets) const {
+    ScriptTriggerActions scriptTriggerActions;
+
+    for(auto& scriptTriggerAction: _scriptTriggerActions)
+        scriptTriggerActions << new ScriptTriggerAction(nullptr, scriptTriggerAction, "Test");
+
+    return scriptTriggerActions;
+}
+
 
 /// ////////////////////// ///
 /// JupyterLauncherFactory ///

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "UserDialogActions.h"
+#include "ScriptDialogAction.h"
 
 #include <BackgroundTask.h>
 #include <ViewPlugin.h>
@@ -79,6 +80,13 @@ public:
     // e.g. "3.11", "3.12"
     void initPythonScripts(const QString& version);
 
+    /**
+     * Get script trigger actions given \p datasets
+     * @param datasets Vector of input datasets
+     * @return Vector of script trigger actions
+     */
+    mv::gui::ScriptTriggerActions getScriptTriggerActions(const mv::Datasets& datasets) const override;
+
 public: // Global settings
     // Python interpreter path
     static QString getPythonInterpreterPath();
@@ -125,8 +133,11 @@ private:
     QString                         _selectedInterpreterVersion;
     QString                         _jupyterPluginFolder;
 
-    using LoadedPythonInterpreters = std::unordered_map<QString, mv::plugin::Plugin*>;
+    using LoadedPythonInterpreters  = std::unordered_map<QString, mv::plugin::Plugin*>;
     LoadedPythonInterpreters        _initializedPythonInterpreters;
+
+    using PythonScripts             = std::vector<std::shared_ptr<PythonScript>>;
+    PythonScripts                   _scriptTriggerActions = {};
 
     mv::BackgroundTask*             _serverBackgroundTask = nullptr;      /** The background task monitoring the Jupyter Server */
     QProcess                        _serverProcess;             /** A detached process for running the Jupyter server */

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -114,6 +114,7 @@ private:
     void setPythonEnv();
     bool installKernel();
     bool optionallyInstallMVWheel();
+    bool initLauncher(const QString& version, int mode);
     bool initPython(bool activateXeus = true);
 
     bool checkPythonVersion() const;

--- a/src/JupyterLauncher/PluginInfo.json
+++ b/src/JupyterLauncher/PluginInfo.json
@@ -2,7 +2,7 @@
     "name": "Jupyter Launcher",
     "version" :  {
         "plugin" : "0.5.0",
-        "core" : ["1.3"]
+        "core" : ["1.4"]
     },
     "dependencies": [ ]
 }

--- a/src/JupyterLauncher/ScriptDialogAction.cpp
+++ b/src/JupyterLauncher/ScriptDialogAction.cpp
@@ -22,7 +22,14 @@
 #include <QStringList>
 #include <QWidget>
 
-ScriptDialog::ScriptDialog(QWidget* parent, const QJsonObject json, const QString scriptPath, const QString interpreterVersion, JupyterLauncher* launcher) :
+PythonScript::PythonScript(const QString& title, const Type& type, const QString& location, const mv::Datasets& datasets, const QString& interpreterVersion, const QJsonObject& json, JupyterLauncher* launcher, QObject* parent) :
+    Script(title, type, Language::Python, mv::util::Version(interpreterVersion), location, datasets, parent),
+    _dialog(nullptr, json, location, interpreterVersion, launcher)
+{
+
+}
+
+ScriptDialog::ScriptDialog(QWidget* parent, const QJsonObject& json, const QString& scriptPath, const QString& interpreterVersion, JupyterLauncher* launcher) :
     QDialog(parent),
     _okButton(this, "Run script"),
     _argumentActions(),

--- a/src/JupyterLauncher/ScriptDialogAction.cpp
+++ b/src/JupyterLauncher/ScriptDialogAction.cpp
@@ -22,8 +22,14 @@
 #include <QStringList>
 #include <QWidget>
 
+inline static QString insertDotAfter3(const QString& v) {
+    QString temp = v;
+    temp.insert(1, ".");
+    return temp;
+}
+
 PythonScript::PythonScript(const QString& title, const Type& type, const QString& location, const mv::Datasets& datasets, const QString& interpreterVersion, const QJsonObject& json, JupyterLauncher* launcher, QObject* parent) :
-    Script(title, type, Language::Python, mv::util::Version(interpreterVersion), location, datasets, parent),
+    Script(title, type, Language::Python, mv::util::Version(insertDotAfter3(interpreterVersion)), location, datasets, parent),
     _dialog(nullptr, json, location, interpreterVersion, launcher)
 {
 

--- a/src/JupyterLauncher/ScriptDialogAction.h
+++ b/src/JupyterLauncher/ScriptDialogAction.h
@@ -49,11 +49,10 @@ public:
      * @param title Script title
      * @param type Script type
      * @param location Script location
-     * @param datasets List of datasets that the script can work with (optional, default is empty)
      * @param languageVersion Version of the scripting language
      * @param parent Pointer to parent object (optional, default is nullptr)
      */
-    explicit PythonScript(const QString& title, const Type& type, const QString& location, const mv::Datasets& datasets, const QString& interpreterVersion, const QJsonObject& json, JupyterLauncher* launcher, QObject* parent = nullptr);
+    explicit PythonScript(const QString& title, const Type& type, const QString& location, const QString& interpreterVersion, const QJsonObject& json, JupyterLauncher* launcher, QObject* parent = nullptr);
 
     /** Runs the script */
     void run() override {

--- a/src/JupyterLauncher/ScriptDialogAction.h
+++ b/src/JupyterLauncher/ScriptDialogAction.h
@@ -2,6 +2,7 @@
 
 #include <actions/TriggerAction.h>
 #include <actions/WidgetAction.h>
+#include <util/Script.h>
 
 #include <unordered_map>
 #include <vector>
@@ -13,11 +14,12 @@
 class QWidget;
 class JupyterLauncher;
 
+
 class ScriptDialog : public QDialog
 {
     Q_OBJECT
 public:
-    ScriptDialog(QWidget* parent, const QJsonObject json, const QString scriptPath, const QString interpreterVersion, JupyterLauncher* launcher);
+    ScriptDialog(QWidget* parent, const QJsonObject& json, const QString& scriptPath, const QString& interpreterVersion, JupyterLauncher* launcher);
 
 private:
     void runScript();
@@ -31,4 +33,30 @@ private:
     std::unordered_map<QString, QString>    _argumentMap;
 
     JupyterLauncher*                        _launcherPlugin = nullptr;
+};
+
+class PythonScript : public mv::util::Script
+{
+    Q_OBJECT
+
+public:
+
+    /**
+     * Construct script with \p type and \p language
+     * @param title Script title
+     * @param type Script type
+     * @param location Script location
+     * @param datasets List of datasets that the script can work with (optional, default is empty)
+     * @param languageVersion Version of the scripting language
+     * @param parent Pointer to parent object (optional, default is nullptr)
+     */
+    explicit PythonScript(const QString& title, const Type& type, const QString& location, const mv::Datasets& datasets, const QString& interpreterVersion, const QJsonObject& json, JupyterLauncher* launcher, QObject* parent = nullptr);
+
+    /** Runs the script */
+    void run() override {
+        _dialog.show();
+    }
+
+private:
+    ScriptDialog _dialog;
 };

--- a/src/JupyterLauncher/ScriptDialogAction.h
+++ b/src/JupyterLauncher/ScriptDialogAction.h
@@ -21,6 +21,8 @@ class ScriptDialog : public QDialog
 public:
     ScriptDialog(QWidget* parent, const QJsonObject& json, const QString& scriptPath, const QString& interpreterVersion, JupyterLauncher* launcher);
 
+    void populateDialog();
+
 private:
     void runScript();
 
@@ -30,6 +32,7 @@ private:
 
     QString                                 _interpreterVersion;
     QString                                 _scriptPath;
+    QJsonObject                             _json;
     std::unordered_map<QString, QString>    _argumentMap;
 
     JupyterLauncher*                        _launcherPlugin = nullptr;
@@ -54,6 +57,7 @@ public:
 
     /** Runs the script */
     void run() override {
+        _dialog.populateDialog();
         _dialog.show();
     }
 

--- a/src/JupyterPlugin/PluginInfo.json
+++ b/src/JupyterPlugin/PluginInfo.json
@@ -2,7 +2,7 @@
     "name": "Jupyter Plugin",
     "version" :  {
         "plugin" : "0.5.0",
-        "core" : ["1.3"]
+        "core" : ["1.4"]
     },
     "dependencies": [ "Points", "Images", "Cluster" ]
 }


### PR DESCRIPTION
Depends on https://github.com/ManiVaultStudio/core/pull/915

Use the new `mv::ScriptingManager` to place script execution entries in the data hierarchy. 

Right clicking the data hierarchy will show loaders, as it does for Loader Plugins:
![image](https://github.com/user-attachments/assets/13d69299-d977-48fa-9d05-73100dadf159)

Right clicking a data set will add all other script types:
![image](https://github.com/user-attachments/assets/a61889da-1d99-4f4e-b0f8-ab1a8ed938a6)

The `input-datatypes` entries in the script config file may be used to restrict listing script for certain data types.