### PR TITLE
More robust dependencies path resolution

### DIFF
--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -41,6 +41,29 @@ using namespace mv;
 
 Q_PLUGIN_METADATA(IID "studio.manivault.JupyterLauncher")
 
+namespace
+ {
+
+    // Transition: replace with util::StandardPaths::getPluginDependenciesDirectory() from <util/StandardPaths.h>
+    QString getPluginDependenciesDirectory()
+    {
+        const auto applicationDir = QDir(QCoreApplication::applicationDirPath());
+        const auto dirName = QString("PluginDependencies");
+
+        auto pathSuffix = QString("/%1/").arg(dirName);
+
+        if constexpr (QOperatingSystemVersion::currentType() == QOperatingSystemVersion::MacOS)
+            pathSuffix = applicationDir.dirName() == "MacOS" ? QString("../../../../%1").arg(dirName) : QString("/../%1").arg(dirName);
+
+        return QDir::cleanPath(applicationDir.path() + pathSuffix);
+    }
+
+	QString getPluginDependenciesFolder()
+	{
+		return getPluginDependenciesDirectory() + "/JupyterLauncher";
+	}
+ }
+
 // =============================================================================
 // JupyterLauncher
 // =============================================================================
@@ -183,7 +206,7 @@ bool JupyterLauncher::ensureMvWheelIsInstalled() const
         }
 
         // Install the manivault wheels
-        const QString mvWheelPath = QDir::toNativeSeparators(QCoreApplication::applicationDirPath() + "/PluginDependencies/JupyterLauncher/py/");
+        const QString mvWheelPath = QDir::toNativeSeparators(getPluginDependenciesFolder() + "/py/");
         const QString kernelWheel = mvWheelPath + "mvstudio_kernel-" + pluginVersion + "-py3-none-any.whl";
         const QString dataWheel = mvWheelPath + "mvstudio_data-" + pluginVersion + "-py3-none-any.whl";
 
@@ -406,7 +429,7 @@ bool JupyterLauncher::initPython(const bool activateXeus)
         qWarning() << "Failed to load/locate python communication plugin";
     }
 
-    QString jupyterPluginPath = QCoreApplication::applicationDirPath() + "/PluginDependencies/JupyterLauncher/bin/JupyterPlugin" + _selectedInterpreterVersion.remove(".");
+    QString jupyterPluginPath = getPluginDependenciesFolder() + "/bin/JupyterPlugin" + _selectedInterpreterVersion.remove(".");
 
     // plugin lib version suffix
     const auto coreVersion  = mv::Application::current()->getVersion();
@@ -735,7 +758,7 @@ void JupyterLauncherFactory::initialize()
     // Position to the right of the status bar action
     _statusBarAction->setIndex(-1);
 
-    const QString jupyterPluginFolder   = QCoreApplication::applicationDirPath() + "/PluginDependencies/JupyterLauncher/bin/";
+    const QString jupyterPluginFolder   = getPluginDependenciesFolder() + "/bin/";
     QStringList pythonPlugins           = findLibraryFiles(jupyterPluginFolder);
 
 	qDebug() << "jupyterPluginFolder:" << jupyterPluginFolder;

--- a/src/JupyterLauncher/JupyterLauncher.cpp
+++ b/src/JupyterLauncher/JupyterLauncher.cpp
@@ -47,7 +47,6 @@ Q_PLUGIN_METADATA(IID "studio.manivault.JupyterLauncher")
 
 JupyterLauncher::JupyterLauncher(const PluginFactory* factory) :
     ViewPlugin(factory),
-    _jupyterPluginFolder(QCoreApplication::applicationDirPath() + "/PluginDependencies/JupyterLauncher/bin/"),
     _serverProcess(this),
     _launcherDialog(std::make_unique<LauncherDialog>(nullptr, this))
 {

--- a/src/JupyterLauncher/JupyterLauncher.h
+++ b/src/JupyterLauncher/JupyterLauncher.h
@@ -106,7 +106,6 @@ private:
     QString                         _connectionFilePath = {};
     QString                         _selectedInterpreterVersion = {};
     QString                         _currentInterpreterPatchVersion = {};
-    QString                         _jupyterPluginFolder = {};
 
     using LoadedPythonInterpreters  = std::unordered_map<QString, mv::plugin::Plugin*>;
     LoadedPythonInterpreters        _initializedPythonInterpreters = {};


### PR DESCRIPTION
Alternative to #61.

The path resolution to the `PluginDependencies` currently does not work well on MacOS in bundled applications since the folder layout is a little different in that case.

This PR copies the recently added `getPluginDependenciesDirectory` from ManiVault's `<util/StandardPaths.h>` to make these changes still compatible with the `1.4.*` core release. A follow-up PR will remove this helper and increase the core-compatibility version.